### PR TITLE
Print queue, initial implementation:

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,5 +1,18 @@
+from couchdb import Server
+
+
+from constants import COUCH_SERVER
+from print_queue import PrintQueue
+
+
 def main():
-    print("Hello, World!")
+    server = Server(COUCH_SERVER)
+    db = server["dev"]
+
+    print_queue = PrintQueue(db, "printer-1")
+
+    for job in print_queue.listen():
+        print(job)
 
 
 if __name__ == "__main__":

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,3 @@
+COUCH_SERVER = "http://admin:admin@localhost:5000"
+
+VERSION = "v1"

--- a/print_job.py
+++ b/print_job.py
@@ -1,0 +1,18 @@
+from couchdb.mapping import Document, TextField
+
+
+class PrintJob(Document):
+    """A CouchDB document mapping for a print job document.
+
+    The print job document is essentially a message stored stored in the print queue part of the
+    database, used to schedule and keep track of print jobs.
+
+    Fields:
+        printer_id: The ID of the printer that this print job is for
+        content: The content of the print job
+
+    TODO: Make this more elaborate, this is just a placeholder
+    """
+
+    printer_id = TextField()
+    content = TextField()

--- a/print_queue.py
+++ b/print_queue.py
@@ -1,0 +1,36 @@
+import time
+
+from constants import VERSION
+
+from print_job import PrintJob
+
+
+class PrintQueue(object):
+    def __init__(self, db, printer_id):
+        self.db = db
+        self.printer_id = printer_id
+
+    def stream_changes(self, since="now", selector=None):
+        last_seq = since
+
+        while True:
+            changes = self.db.changes(
+                since=last_seq,
+                feed="longpoll",
+                heartbeat=10000,
+                headers={"Content-Type": "application/json"},
+                filter="_selector",
+                _selector=selector,
+            )
+            last_seq = changes["last_seq"]
+            for change in changes["results"]:
+                yield change
+            time.sleep(1)
+
+    def listen(self):
+        basepath = f"{VERSION}/print_queue/{self.printer_id}"
+        selector = {
+            "selector": {"_id": {"$gte": f"{basepath}/", "$lt": f"{basepath}0"}}
+        }
+        for change in self.stream_changes(selector=selector):
+            yield PrintJob.load(self.db, change.get("id"))


### PR DESCRIPTION
* Create a (placeholder) PrintJob document mapping
* Create a PrintQueue class and set up the listening logic

### To test this out (manually): 
- Start up docker compose of the main app (librocco/web-client) 
- start the dev server (librocco/web-client)
- navigate to the app (localhost:5173) and, in the dev tools console, create a function `enqueue`:
```ts
// Initialise the counter
i = 0
function counter() { return i++ }

// Enqueue
function enqueue() {
  // window._db is defined (we've set it up so for e2e tests)
  return _db
    ._pouch
    .put({ _id: `v1/print_queue/printer-1/job-${counter()}`, printer_id: "printer-1", content: "Print This!" })
}
```
- start this program (`python .`) since the logic is in `__main__.py`
- run `enqueue()` from the browser a couple of times
- each time `enqueue()` is ran, the output of this program should display the document change
